### PR TITLE
Update pull-request-assignee.yml

### DIFF
--- a/.github/workflows/pull-request-assignee.yml
+++ b/.github/workflows/pull-request-assignee.yml
@@ -10,9 +10,6 @@ on:
       - 'stable'
       - 'release/v*'
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-
 jobs:
   assign-assignees:
     runs-on: ubuntu-latest
@@ -21,6 +18,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Assign PR creator
-        uses: actions-ecosystem/action-add-assignees@v1
+        uses: dafneb/.github/.github/workflows/pull-request-assignee.yml@main
         with:
           assignees: ${{ github.actor }}
+        secrets: inherit


### PR DESCRIPTION
This pull request updates the `pull-request-assignee.yml` workflow file to modify its trigger configuration and update the action used for assigning pull request creators. 

Workflow trigger updates:

* Removed the `workflow_dispatch` trigger, which allowed the workflow to be run manually from the Actions tab.

Action configuration updates:

* Replaced the `actions-ecosystem/action-add-assignees@v1` action with a custom action hosted at `dafneb/.github/.github/workflows/pull-request-assignee.yml@main`.
* Added the `secrets: inherit` configuration to the updated action.