### PR TITLE
Dafneb patch 1

### DIFF
--- a/.github/workflows/pull-request-assignee.yml
+++ b/.github/workflows/pull-request-assignee.yml
@@ -12,13 +12,7 @@ on:
 
 jobs:
   assign-assignees:
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      pull-requests: write
-    steps:
-      - name: Assign PR creator
-        uses: dafneb/.github/.github/workflows/pull-request-assignee.yml@main
-        with:
-          assignees: ${{ github.actor }}
-        secrets: inherit
+    uses: dafneb/.github/.github/workflows/pull-request-assignee.yml@main
+      with:
+        assignees: ${{ github.actor }}
+      secrets: inherit

--- a/.github/workflows/pull-request-assignee.yml
+++ b/.github/workflows/pull-request-assignee.yml
@@ -10,9 +10,6 @@ on:
       - 'stable'
       - 'release/v*'
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
-
 jobs:
   assign-assignees:
     runs-on: ubuntu-latest
@@ -21,6 +18,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Assign PR creator
-        uses: actions-ecosystem/action-add-assignees@v1
+        uses: dafneb/.github/.github/workflows/pull-request-assignee.yml@main
         with:
           assignees: ${{ github.actor }}
+        secrets: inherit


### PR DESCRIPTION
This pull request modifies the `pull-request-assignee.yml` workflow to simplify its implementation by reusing a shared workflow and removing redundant configuration.

Workflow simplification:

* [`.github/workflows/pull-request-assignee.yml`](diffhunk://#diff-55920744bed76ffe7524d52cc611ba95f8841554c7f7efeec7887d588ff53288L13-R18): Replaced the inline job definition with a reference to a shared workflow (`dafneb/.github/.github/workflows/pull-request-assignee.yml@main`) and removed the manual trigger (`workflow_dispatch`). Additionally, the `secrets: inherit` option was added to ensure secrets are passed to the shared workflow.